### PR TITLE
Resolve #6: add basic v1 test cases

### DIFF
--- a/returncheck_test.go
+++ b/returncheck_test.go
@@ -1,0 +1,14 @@
+package returncheck
+
+import (
+	"testing"
+
+	"golang.org/x/tools/go/analysis/analysistest"
+)
+
+func TestReturncheck(t *testing.T) {
+	t.Run("v1 test cases, default configuration", func(t *testing.T) {
+		t.Skip("enabled once v1 is ready for release")
+		analysistest.Run(t, analysistest.TestData(), Analyzer, "v1/...")
+	})
+}

--- a/testdata/src/v1/point/point.go
+++ b/testdata/src/v1/point/point.go
@@ -1,0 +1,32 @@
+package point
+
+type Point struct {
+	X int
+	Y int
+}
+
+func (me Point) SetX(x int) Point {
+	me.X = x
+	return me
+}
+
+func (me Point) SetY(y int) Point {
+	me.Y = y
+	return me
+}
+
+func (me Point) Copy() Point {
+	return me
+}
+
+func (me Point) GetX() int {
+	return me.X
+}
+
+func (me Point) GetY() int {
+	return me.Y
+}
+
+func (me Point) Unpack() (int, int) {
+	return me.X, me.Y
+}

--- a/testdata/src/v1/v1.go
+++ b/testdata/src/v1/v1.go
@@ -1,0 +1,64 @@
+package v1
+
+import (
+	"fmt"
+	"math"
+
+	"v1/point"
+)
+
+func computeDistanceBetweenPoints(a, b point.Point) float64 {
+	dx := b.GetX() - a.GetY()
+	dy := b.GetY() - a.GetY()
+	b.GetX() // want `RETC1: return value for function call b.GetX() is ignored`
+	return math.Sqrt(float64(computeSquaredDistance(dx, dy)))
+}
+
+func computeSquaredDistance(dx, dy int) int {
+	return dx*dx + dy*dy
+}
+
+func SpecialSumOfDistances(target point.Point, points []point.Point) float64 {
+	var out float64
+	target.Unpack()              // want `RETC1: return values for function call target.Unpack() are ignored`
+	target.Copy().Copy().SetY(5) // want `RETC1: return value for function call target.Copy().Copy().SetY(...) is ignored`
+	target.Copy()                // want `RETC1: return value for function call target.Copy() is ignored`
+	switch target.GetX() {
+	case target.GetY():
+		return 0
+	}
+	for _, point := range points {
+		computeDistanceBetweenPoints(target.Copy(), point) // want `RETC1: return value for function call computeDistanceBetweenPoints(\.\.\.) is ignored`
+		out += computeDistanceBetweenPoints(target.Copy(), point)
+		_ = computeDistanceBetweenPoints(target.Copy(), point) // this is okay... for now
+	}
+	return out
+}
+
+type Handler struct {
+}
+
+type HandlerRequest struct {
+	Target point.Point
+	Others []point.Point
+}
+
+type HandlerResponse struct {
+	DistanceSum float64
+}
+
+func (me *Handler) emit(msg string) (int, error) {
+	return fmt.Println(msg)
+}
+
+func (me *Handler) HandleRequest(req HandlerRequest) HandlerResponse {
+	go me.emit("In middling of handling request") // don't complain if return value is ignored when spawning Goroutine
+	me.emit("Handling request")                   // want `RETC1: return values for function call me.emit(...) are ignored`
+	defer me.emit("Handled request")              // don't complain if return value is ignored in `defer` call
+	output := SpecialSumOfDistances(req.Target, req.Others)
+	output = SpecialSumOfDistances(req.Target, req.Others)
+	_ = output
+	return HandlerResponse{
+		DistanceSum: output,
+	}
+}

--- a/testdata/src/v1/v1.go
+++ b/testdata/src/v1/v1.go
@@ -18,6 +18,9 @@ func computeSquaredDistance(dx, dy int) int {
 	return dx*dx + dy*dy
 }
 
+func returnsNoValues() {
+}
+
 func SpecialSumOfDistances(target point.Point, points []point.Point) float64 {
 	var out float64
 	target.Unpack()              // want `RETC1: return values for function call target.Unpack() are ignored`
@@ -57,6 +60,7 @@ func (me *Handler) HandleRequest(req HandlerRequest) HandlerResponse {
 	defer me.emit("Handled request")              // don't complain if return value is ignored in `defer` call
 	output := SpecialSumOfDistances(req.Target, req.Others)
 	output = SpecialSumOfDistances(req.Target, req.Others)
+	returnsNoValues()
 	_ = output
 	return HandlerResponse{
 		DistanceSum: output,


### PR DESCRIPTION
Add test cases in `testdata/src/v1` for the v1 functionality, i.e. rejecting expression statements. The main test code is in `returncheck_test.go`.

These tests cover the following scenarios:
  - `defer` on a function that returns values
  - `go func` on a function that returns values
  - `fmt.Println`
  - Function calls used in switch tags and case labels
  - Regular assignments and declaration assignments
  - `+=`
  - Function calls used in binary expressions
  - Assignments to `_`
  - Methods
  - Chained method calls