### PR TITLE
create ast visitor functions

### DIFF
--- a/analyzer/analyzer.go
+++ b/analyzer/analyzer.go
@@ -75,7 +75,7 @@ func functionName(call *ast.CallExpr) string {
 	case *ast.Ident:
 		return fun.Name + "()"
 	case *ast.SelectorExpr:
-		return fmt.Sprintf("%s.%s()", exprString(fun.X), fun.Sel.Name)
+		return fmt.Sprintf("%s.%s", exprString(fun.X), fun.Sel.Name)
 	}
 	return ""
 }
@@ -87,7 +87,7 @@ func exprString(expr ast.Expr) string {
 	case *ast.SelectorExpr:
 		return fmt.Sprintf("%s.%s", exprString(e.X), e.Sel.Name)
 	case *ast.CallExpr:
-		return fmt.Sprintf("%s()", functionName(e))
+		return fmt.Sprintf("%s", functionName(e))
 	}
 	return ""
 }

--- a/analyzer/analyzer.go
+++ b/analyzer/analyzer.go
@@ -33,16 +33,21 @@ func run(pass *analysis.Pass) (interface{}, error) {
 			switch expr := stmt.X.(type) {
 			case *ast.CallExpr:
 				// Report the standalone function call
-    				pass.Reportf(callExpr.Pos(), "RETC1: return value for function call %s is ignored", callExpr.Sel.Name)
+				pass.Reportf(expr.Pos(), "RETC1: return value for function call %s is ignored", formatNode(pass, expr))
 			case *ast.SelectorExpr:
 				// Check if the selector expression's X is a call expression
-				if _, ok := expr.X.(*ast.CallExpr); ok {
+				if callExpr, ok := expr.X.(*ast.CallExpr); ok {
 					// Report the standalone function call in the selector
-					pass.Reportf(callExpr.Pos(), "RETC1: return value for function call %s is ignored", callExpr.Sel.Name)
+					pass.Reportf(callExpr.Pos(), "RETC1: return value for function call %s is ignored", formatNode(pass, callExpr))
 				}
 			}
 		}
 	})
 
 	return nil, nil
+}
+
+// formatNode formats the given AST node as a string.
+func formatNode(pass *analysis.Pass, node ast.Node) string {
+	return pass.Fset.Position(node.Pos()).String()
 }

--- a/analyzer/analyzer.go
+++ b/analyzer/analyzer.go
@@ -6,7 +6,6 @@ import (
 	"golang.org/x/tools/go/analysis"
 	"golang.org/x/tools/go/analysis/passes/inspect"
 	"golang.org/x/tools/go/ast/inspector"
-	"strings"
 )
 
 // NewAnalyzer returns a new analyzer.

--- a/analyzer/analyzer.go
+++ b/analyzer/analyzer.go
@@ -33,12 +33,12 @@ func run(pass *analysis.Pass) (interface{}, error) {
 			switch expr := stmt.X.(type) {
 			case *ast.CallExpr:
 				// Report the standalone function call
-				pass.Reportf(expr.Pos(), "standalone function call found: %s", pass.Fset.Position(expr.Pos()))
+    				pass.Reportf(callExpr.Pos(), "RETC1: return value for function call %s is ignored", callExpr.Sel.Name)
 			case *ast.SelectorExpr:
 				// Check if the selector expression's X is a call expression
 				if _, ok := expr.X.(*ast.CallExpr); ok {
 					// Report the standalone function call in the selector
-					pass.Reportf(expr.Pos(), "standalone function call found in selector: %s", pass.Fset.Position(expr.Pos()))
+					pass.Reportf(callExpr.Pos(), "RETC1: return value for function call %s is ignored", callExpr.Sel.Name)
 				}
 			}
 		}

--- a/analyzer/analyzer.go
+++ b/analyzer/analyzer.go
@@ -1,0 +1,48 @@
+package analyzer
+
+import (
+	"go/ast"
+	"golang.org/x/tools/go/analysis"
+	"golang.org/x/tools/go/analysis/passes/inspect"
+	"golang.org/x/tools/go/ast/inspector"
+)
+
+// NewAnalyzer returns a new analyzer.
+func NewAnalyzer() *analysis.Analyzer {
+	return &analysis.Analyzer{
+		Name:     "standaloneFuncCalls",
+		Doc:      "Reports standalone function calls",
+		Run:      run,
+		Requires: []*analysis.Analyzer{inspect.Analyzer},
+	}
+}
+
+func run(pass *analysis.Pass) (interface{}, error) {
+	insp := pass.ResultOf[inspect.Analyzer].(*inspector.Inspector)
+
+	nodeFilter := []ast.Node{
+		(*ast.ExprStmt)(nil),     // to find expression statements
+		(*ast.CallExpr)(nil),     // to find call expressions
+		(*ast.SelectorExpr)(nil), // to find selector expressions
+	}
+
+	insp.Preorder(nodeFilter, func(n ast.Node) {
+		switch stmt := n.(type) {
+		case *ast.ExprStmt:
+			// Check if the expression is a call expression
+			switch expr := stmt.X.(type) {
+			case *ast.CallExpr:
+				// Report the standalone function call
+				pass.Reportf(expr.Pos(), "standalone function call found: %s", pass.Fset.Position(expr.Pos()))
+			case *ast.SelectorExpr:
+				// Check if the selector expression's X is a call expression
+				if _, ok := expr.X.(*ast.CallExpr); ok {
+					// Report the standalone function call in the selector
+					pass.Reportf(expr.Pos(), "standalone function call found in selector: %s", pass.Fset.Position(expr.Pos()))
+				}
+			}
+		}
+	})
+
+	return nil, nil
+}

--- a/analyzer/analyzer.go
+++ b/analyzer/analyzer.go
@@ -55,10 +55,17 @@ func run(pass *analysis.Pass) (interface{}, error) {
 }
 
 func returnsValues(pass *analysis.Pass, call *ast.CallExpr) bool {
-	if t, ok := pass.TypesInfo.Types[call]; ok {
-		return t.Type != types.Typ[types.Invalid] && t.Type != nil
-	}
-	return false
+    if t, ok := pass.TypesInfo.Types[call]; ok {
+        switch typ := t.Type.(type) {
+        case *types.Tuple:
+            return typ.Len() > 0
+        case *types.Named, *types.Struct, *types.Basic, *types.Pointer, *types.Interface:
+            return true
+        case *types.Signature:
+            return typ.Results().Len() > 0
+        }
+    }
+    return false
 }
 
 func hasMultipleReturnValues(pass *analysis.Pass, call *ast.CallExpr) bool {

--- a/analyzer/analyzer_test.go
+++ b/analyzer/analyzer_test.go
@@ -9,7 +9,7 @@ import (
 	"golang.org/x/tools/go/analysis/analysistest"
 )
 
-var testdataPath, _ = filepath.Abs("./testdata/") //nolint:gochecknoglobals
+var testdataPath, _ = filepath.Abs("../testdata/") //nolint:gochecknoglobals
 
 func TestAnalyzer(t *testing.T) {
 	t.Parallel()

--- a/analyzer/analyzer_test.go
+++ b/analyzer/analyzer_test.go
@@ -1,0 +1,22 @@
+package analyzer_test
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/navijation/go-returncheck/analyzer"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/tools/go/analysis/analysistest"
+)
+
+var testdataPath, _ = filepath.Abs("./testdata/") //nolint:gochecknoglobals
+
+func TestAnalyzer(t *testing.T) {
+	t.Parallel()
+
+	a := analyzer.NewAnalyzer()
+
+	require.NotNil(t, a)
+
+	analysistest.Run(t, testdataPath, a, "v1")
+}

--- a/go.mod
+++ b/go.mod
@@ -2,9 +2,15 @@ module github.com/navijation/go-returncheck
 
 go 1.22.3
 
-require golang.org/x/tools v0.21.0
+require (
+	github.com/stretchr/testify v1.9.0
+	golang.org/x/tools v0.21.0
+)
 
 require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	golang.org/x/mod v0.17.0 // indirect
 	golang.org/x/sync v0.7.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,16 @@
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
+github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 golang.org/x/mod v0.17.0 h1:zY54UmvipHiNd+pm+m0x9KhZ9hl1/7QNMyxXbc6ICqA=
 golang.org/x/mod v0.17.0/go.mod h1:hTbmBsO62+eylJbnUtE2MGJUyE7QWk4xUqPFrRgJ+7c=
 golang.org/x/sync v0.7.0 h1:YsImfSBoP9QPYL0xyKJPq0gcaJdG3rInoqxTWbfQu9M=
 golang.org/x/sync v0.7.0/go.mod h1:Czt+wKu1gCyEFDUtn0jG5QVvpJ6rzVqr5aXyt9drQfk=
 golang.org/x/tools v0.21.0 h1:qc0xYgIbsSDt9EyWz05J5wfa7LOVW0YTLOXrqdLAWIw=
 golang.org/x/tools v0.21.0/go.mod h1:aiJjzUbINMkxbQROHiO6hDPo2LHcIPhhQsa9DLh0yGk=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/testdata/src/v1/v1.go
+++ b/testdata/src/v1/v1.go
@@ -10,7 +10,7 @@ import (
 func computeDistanceBetweenPoints(a, b point.Point) float64 {
 	dx := b.GetX() - a.GetY()
 	dy := b.GetY() - a.GetY()
-	b.GetX() // want `RETC1: return value for function call b.GetX() is ignored`
+	b.GetX() // want "RETC1: return value for function call b.GetX() is ignored"
 	return math.Sqrt(float64(computeSquaredDistance(dx, dy)))
 }
 
@@ -23,15 +23,15 @@ func returnsNoValues() {
 
 func SpecialSumOfDistances(target point.Point, points []point.Point) float64 {
 	var out float64
-	target.Unpack()              // want `RETC1: return values for function call target.Unpack() are ignored`
-	target.Copy().Copy().SetY(5) // want `RETC1: return value for function call target.Copy().Copy().SetY(...) is ignored`
-	target.Copy()                // want `RETC1: return value for function call target.Copy() is ignored`
+	target.Unpack() // want "RETC1: return values for function call target.Unpack() are ignored"
+	target.Copy().Copy().SetY(5) // want "RETC1: return value for function call target.Copy().Copy().SetY() is ignored"
+	target.Copy() // want "RETC1: return value for function call target.Copy() is ignored"
 	switch target.GetX() {
 	case target.GetY():
 		return 0
 	}
 	for _, point := range points {
-		computeDistanceBetweenPoints(target.Copy(), point) // want `RETC1: return value for function call computeDistanceBetweenPoints(\.\.\.) is ignored`
+		computeDistanceBetweenPoints(target.Copy(), point) // want "RETC1: return value for function call computeDistanceBetweenPoints() is ignored"
 		out += computeDistanceBetweenPoints(target.Copy(), point)
 		_ = computeDistanceBetweenPoints(target.Copy(), point) // this is okay... for now
 	}
@@ -56,8 +56,8 @@ func (me *Handler) emit(msg string) (int, error) {
 
 func (me *Handler) HandleRequest(req HandlerRequest) HandlerResponse {
 	go me.emit("In middling of handling request") // don't complain if return value is ignored when spawning Goroutine
-	me.emit("Handling request")                   // want `RETC1: return values for function call me.emit(...) are ignored`
-	defer me.emit("Handled request")              // don't complain if return value is ignored in `defer` call
+	me.emit("Handling request") // want "RETC1: return values for function call me.emit() are ignored"
+	defer me.emit("Handled request") // don't complain if return value is ignored in `defer` call
 	output := SpecialSumOfDistances(req.Target, req.Others)
 	output = SpecialSumOfDistances(req.Target, req.Others)
 	returnsNoValues()


### PR DESCRIPTION
[Issue Description](https://github.com/navijation/go-returncheck/issues/3)

**New Analyzer for Standalone Function Calls**
This PR introduces a new analyzer to detect standalone function calls in Go code where the return value is ignored. The analyzer flags function calls that are standalone statements but whose return values are not used or assigned. This ensures that important return values are not inadvertently ignored, leading to potential bugs or unintended behavior.

**Features**
Standalone Function Call Detection: The analyzer identifies function calls that are standalone statements and whose return values are ignored.
Selective Enforcement: Certain scenarios such as goroutines, deferred calls, and specific patterns are exempt from enforcement based on the analysis requirements.

Example Cases
Cases of Interest:
```
func main() {
    Foo()
    Bar()
    _ = buildCtx("hello")
    localFunc := func() int { return 5 }
    if true {
        localFunc()
    }
    a().b().c() // Only the call to c() is of interest
}

```
Cases Not of Interest:

```
func main() {
    ctx := buildCtx("hello")
    x := sin(5) + cos(5)
    someFunctionNoReturnValues(sin(cos(5)))
    switch makeMyEnum() {
    case makeFive():
        fmt.Println("Got five")
    }
    makeMyLogger().LogReturnNoValues("hello")
    go func() int { return 5 }()
    defer func() int { return 6 }()
}
```